### PR TITLE
Fix(actions): Update deprecated actions to remove warnings

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -42,14 +42,14 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "YARN_CACHE_DIR_PATH=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3
         id: yarn-cache
         with:
           path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            ${{ steps.yarn-cache-dir-path.outputs.YARN_CACHE_DIR_PATH }}
             **/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -24,14 +24,14 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "YARN_CACHE_DIR_PATH=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3
         id: yarn-cache
         with:
           path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            ${{ steps.yarn-cache-dir-path.outputs.YARN_CACHE_DIR_PATH }}
             **/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |


### PR DESCRIPTION
# Fix(actions): Update deprecated actions to remove warnings

- Github set-output command is deprecated
- Android Sign action uses node 12, use now own forked and updated action for signing

Affected code (keywords like: STORE, DOCS, ANIMATIONS, CONFIG etc.):

- AFFECTED_CODE

Fixes:

- #ISSUE: ISSUE_NAME

Depedenscies:

- OFFICIAL_PACKAGE_NAME

Changed permissions:

- PERMISSION_NAME

## How Has This Been Tested?

Describe the tests that you ran to verify your changes:

-

(optional) Provide instructions to reproduce:

-

(optional) List any relevant details for your test configuration:

-

- [ ] Tested on Android Device DEVICE_NAME with Version ANDROID_VERSION
- [ ] Tested on iPhone DEVICE_NAME with Version IOS_VERSION
- [ ] Further test:

## Checklist:

- [ ] Code follows style guidelines
- [ ] Self review of code
- [ ] Commented code, particularly in hard-to-understand areas
- [ ] Updated documentation
- [ ] No new warnings exist
- [ ] Added unittests
- [ ] Unit tests pass locally and in CI
