### PR TITLE
feat(input, keyboard): Show numpad on number inputs

### DIFF
--- a/src/components/inputs/CInput.vue
+++ b/src/components/inputs/CInput.vue
@@ -6,6 +6,7 @@
     @update="$emit('value', $event)"
     :label="label"
     :rules="rules"
+    :type="type"
   >
     <slot></slot>
   </q-input>
@@ -13,6 +14,10 @@
 
 <script setup lang="ts">
 defineProps({
+  type: {
+    type: null,
+    default: 'text'
+  },
   value: {
     type: String,
     reqired: true

--- a/src/pages/refuels/RefuelForm.vue
+++ b/src/pages/refuels/RefuelForm.vue
@@ -2,6 +2,7 @@
   <div>
     <q-form @submit="onSubmit" class="q-pa-md q-gutter-md">
       <c-input
+        type="tel"
         :value="refuel.payedAmount?.toString()"
         @update:modelValue="(evt: string) => (refuel.payedAmount = replaceComma(evt))"
         label="Payed amount"
@@ -14,6 +15,7 @@
         autofocus
       />
       <c-input
+        type="tel"
         :value="refuel.distanceDriven?.toString()"
         @update:modelValue="(evt: string) => (refuel.distanceDriven = replaceComma(evt))"
         label="Distance driven"
@@ -25,6 +27,7 @@
         ]"
       />
       <c-input
+        type="tel"
         :value="refuel.refueledAmount?.toString()"
         @update:modelValue="(evt: string) => (refuel.refueledAmount = replaceComma(evt))"
         label="Refuled amount"


### PR DESCRIPTION
# feat(input, keyboard): Show numpad on number inputs

- Extend custom input with "type" property
- Use "tel" type on number inputs to show numpad and to keep ability to enter comma seperated types
