### PR TITLE
fix(settings): Initialize settings on boot

### DIFF
--- a/src/boot/init.ts
+++ b/src/boot/init.ts
@@ -1,10 +1,11 @@
-import { useRefuelFilterStore } from 'src/pages/refuels/stores/refuelFilterStore'
+import { initSettings } from 'src/scripts/initSettings'
+initSettings()
 
+import { useRefuelFilterStore } from 'src/pages/refuels/stores/refuelFilterStore'
 const refuelFilterStore = useRefuelFilterStore()
 refuelFilterStore.readFilter()
 
 import { registerGraphData } from 'src/pages/graphData/scripts/registerGraphData'
 import { registerFuelConsumption } from 'src/scripts/libraries/refuel/functions/fuelConsumption/registerFuelConsumption'
-
 registerGraphData()
 registerFuelConsumption()

--- a/src/pages/graphData/GraphData.vue
+++ b/src/pages/graphData/GraphData.vue
@@ -69,7 +69,6 @@ import packageJson from '../../../package.json'
 import { useRefuelStore } from 'src/stores/refuelStore'
 import { useSettingsStore } from 'src/stores/settingsStore'
 import { useGraphDataStore } from './stores/graphDataStore'
-import { initSettings } from 'src/scripts/initSettings'
 import { GraphData, Period } from 'src/pages/graphData/scripts/models'
 import {
   OptionInDialog,
@@ -144,7 +143,6 @@ watchEffect(() => {
 })
 
 onBeforeMount(async () => {
-  initSettings()
   periods.value = await refuelStore.getPeriods()
 })
 


### PR DESCRIPTION
# fix(settings): Initialize settings on boot

- Initialize settings on boot instead on every GraphPage mount

## Checklist

Check all boxes that apply:

- [ ] Tests created
- [ ] Changes tested on latest device API
- [X] Self review of changes
- [X] Pipeline ok
