### PR TITLE
fix(theme): Remove splashscreen when highlighting text

### DIFF
--- a/src-capacitor/android/app/src/main/res/values/styles.xml
+++ b/src-capacitor/android/app/src/main/res/values/styles.xml
@@ -15,7 +15,6 @@
     <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:background">@drawable/splash</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="android:colorBackground">@color/colorPrimary</item>
@@ -25,7 +24,6 @@
     <style name="AppTheme.NoActionBarLaunch" parent="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:background">@drawable/splash</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="android:colorBackground">@color/colorPrimary</item>


### PR DESCRIPTION
# fix(theme): Remove splashscreen when highlighting text

## Checklist

Check all boxes that apply:

- [ ] Tests created
- [X] Changes tested on latest device API
- [X] Self review of changes
- [X] Pipeline ok
