### PR TITLE
refactor(mainlayout api): Use vue native functions instead of events

### DIFF
--- a/src/boot/mitt.ts
+++ b/src/boot/mitt.ts
@@ -1,13 +1,9 @@
 import mitt from 'mitt'
 
 type Events = {
-  updateTitle: string
   showGraphOptionsDialog: unknown
   showVehicleOptionsDialog: number
   showRefuelOptionsDialog: number
-  selectedVehicleChanged: boolean
-  showSaveButton: boolean
-  save: boolean
 }
 
 export const emitter = mitt<Events>()

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -36,7 +36,7 @@ export default {
   form: {
     cancel: 'Cancel',
     confirm: 'Confirm',
-    filter: 'Filtern'
+    filter: 'Filter'
   },
   placeholders: {
     addRefuel: 'Add refuel',

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <q-layout view="lHh Lpr lFf" class="bg-space-station">
-    <q-header ref="header" class="bg-space-station">
+    <q-header id="header" class="bg-space-station">
       <q-toolbar>
         <q-btn
           flat
@@ -39,17 +39,9 @@
         />
       </q-toolbar>
 
-      <div v-if="false" class="column items-center">
-        <div class="row q-gutter-xs q-pb-xs">
-          <q-btn
-            class="col justify-center q-px-sm"
-            color="negative"
-            icon="cancel"
-            size="sm"
-            dense
-            >filter
-          </q-btn>
-        </div>
+      <div id="header-badges-left" class="row q-gutter-xs"></div>
+      <div class="column items-center">
+        <div id="header-badges-center" class="row q-gutter-xs q-pb-xs"></div>
       </div>
     </q-header>
 
@@ -81,7 +73,7 @@
       </router-view>
     </q-page-container>
 
-    <q-footer v-if="footerVisible" class="bg-space-station" ref="footer">
+    <q-footer v-if="footerVisible" class="bg-space-station" id="footer">
       <q-toolbar class="q-gutter-xs text-center">
         <div class="col">
           <q-btn round flat dense icon="bar_chart" class="col" :to="'/'" />
@@ -140,8 +132,6 @@ const settingsStore = useSettingsStore()
 const mainLayoutStore = useMainLayoutStore()
 const routePath = computed(() => router.currentRoute.value.path)
 const { t } = useI18n()
-const header = ref()
-const footer = ref()
 
 const linkList = ref([
   {
@@ -196,12 +186,13 @@ function toggleLeftDrawer() {
 }
 
 function calculateAreaHeight() {
-  settingsStore.areaHeight =
-    document.documentElement.clientHeight -
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    header.value.heightHint -
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    footer.value.heightHint
+  var header = document.getElementById('header')
+  var footer = document.getElementById('footer')
+  if (header && footer)
+    settingsStore.areaHeight =
+      document.documentElement.clientHeight -
+      header.getBoundingClientRect().height -
+      footer.getBoundingClientRect().height
 }
 
 onMounted(() => {
@@ -217,6 +208,7 @@ onMounted(() => {
     calculateAreaHeight()
   })
   calculateAreaHeight()
+  mainLayoutStore.calculateAreaHeight = calculateAreaHeight
 })
 
 onUnmounted(() => {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -12,7 +12,7 @@
         />
 
         <q-toolbar-title>
-          {{ title }}
+          {{ mainLayoutStore.titleText }}
         </q-toolbar-title>
 
         <q-btn
@@ -129,13 +129,15 @@ import EssentialLink from 'components/EssentialLink.vue'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { emitter } from 'src/boot/mitt'
-import { useSettingsStore } from 'src/pages/settings/stores/settingsStore'
+import { useSettingsStore } from 'src/pages/settings/stores'
+import { useMainLayoutStore } from 'src/layouts/stores'
 import { Keyboard } from '@capacitor/keyboard'
 import { Platform } from 'quasar'
 import { useI18n } from 'vue-i18n'
 
 const router = useRouter()
 const settingsStore = useSettingsStore()
+const mainLayoutStore = useMainLayoutStore()
 const routePath = computed(() => router.currentRoute.value.path)
 const { t } = useI18n()
 const header = ref()
@@ -177,7 +179,6 @@ const linkList = ref([
 const footerVisible = ref(true)
 const saveButtonVisible = ref(false)
 const leftDrawerOpen = ref(false)
-const title = ref('')
 
 function addKeyboardListeners() {
   if (Platform.is.mobile) {
@@ -216,7 +217,6 @@ onMounted(() => {
     addKeyboardListeners()
   }
 
-  emitter.on('updateTitle', e => (title.value = e))
   emitter.on('showSaveButton', e => (saveButtonVisible.value = e))
 
   addEventListener('resize', () => {
@@ -226,7 +226,6 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  emitter.off('updateTitle')
   emitter.off('showSaveButton')
   removeEventListener('resize', calculateAreaHeight)
 })

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -16,14 +16,15 @@
         </q-toolbar-title>
 
         <q-btn
-          v-if="mainLayoutStore.saveButtonVisible"
+          v-if="mainLayoutStore.saveButton.visible"
           class="q-pt-xs q-pl-md q-mt-md q-mr-xs"
           color="accent"
           label=""
           icon="save"
           no-caps
           unelevated
-          @click="mainLayoutStore.saveButtonAction()"
+          :disable="mainLayoutStore.saveButton.disabled"
+          @click="mainLayoutStore.saveButton.action()"
         />
 
         <q-btn
@@ -92,10 +93,10 @@
             dense
             icon="add"
             class="col"
-            @click="add()"
+            @click="mainLayoutStore.addButton.action()"
             :disable="
-              !settingsStore.selectedVehicleId &&
-              !routePath.includes('/vehicles')
+              !settingsStore.selectedVehicleId ||
+              mainLayoutStore.addButton.disabled
             "
           />
         </div>
@@ -194,13 +195,6 @@ function toggleLeftDrawer() {
   leftDrawerOpen.value = !leftDrawerOpen.value
 }
 
-function add() {
-  if (routePath.value.includes('/add') || routePath.value.includes('/edit'))
-    return
-  else if (routePath.value == '/vehicles') void router.push('/vehicles/add')
-  else void router.push('/refuels/add')
-}
-
 function calculateAreaHeight() {
   settingsStore.areaHeight =
     document.documentElement.clientHeight -
@@ -211,6 +205,10 @@ function calculateAreaHeight() {
 }
 
 onMounted(() => {
+  router.beforeEach(() => {
+    mainLayoutStore.addButton.action = () => void router.push('/refuels/add')
+  })
+
   if (Platform.is.mobile) {
     addKeyboardListeners()
   }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -16,14 +16,14 @@
         </q-toolbar-title>
 
         <q-btn
-          v-if="saveButtonVisible"
+          v-if="mainLayoutStore.saveButtonVisible"
           class="q-pt-xs q-pl-md q-mt-md q-mr-xs"
           color="accent"
           label=""
           icon="save"
           no-caps
           unelevated
-          @click="emitter.emit('save', true)"
+          @click="mainLayoutStore.saveButtonAction()"
         />
 
         <q-btn
@@ -128,7 +128,6 @@
 import EssentialLink from 'components/EssentialLink.vue'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { emitter } from 'src/boot/mitt'
 import { useSettingsStore } from 'src/pages/settings/stores'
 import { useMainLayoutStore } from 'src/layouts/stores'
 import { Keyboard } from '@capacitor/keyboard'
@@ -177,7 +176,6 @@ const linkList = ref([
 ])
 
 const footerVisible = ref(true)
-const saveButtonVisible = ref(false)
 const leftDrawerOpen = ref(false)
 
 function addKeyboardListeners() {
@@ -217,8 +215,6 @@ onMounted(() => {
     addKeyboardListeners()
   }
 
-  emitter.on('showSaveButton', e => (saveButtonVisible.value = e))
-
   addEventListener('resize', () => {
     calculateAreaHeight()
   })
@@ -226,7 +222,6 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  emitter.off('showSaveButton')
   removeEventListener('resize', calculateAreaHeight)
 })
 </script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -16,23 +16,11 @@
         </q-toolbar-title>
 
         <q-btn
-          v-if="mainLayoutStore.saveButton.visible"
-          class="q-pt-xs q-pl-md q-mt-md q-mr-xs"
-          color="accent"
-          label=""
-          icon="save"
-          no-caps
-          unelevated
-          :disable="mainLayoutStore.saveButton.disabled"
-          @click="mainLayoutStore.saveButton.action()"
-        />
-
-        <q-btn
-          v-if="
-            routePath == '/refuels' || routePath.match('\/refuels\/[-0-9]+')
-          "
-          :to="'/refuels/filter'"
-          icon="filter_list"
+          v-if="mainLayoutStore.headerButton.visible"
+          @click="mainLayoutStore.headerButton.action()"
+          :icon="mainLayoutStore.headerButton.icon"
+          :color="mainLayoutStore.headerButton.color"
+          :disable="mainLayoutStore.headerButton.disabled"
           round
           flat
           dense
@@ -130,7 +118,6 @@ import { useI18n } from 'vue-i18n'
 const router = useRouter()
 const settingsStore = useSettingsStore()
 const mainLayoutStore = useMainLayoutStore()
-const routePath = computed(() => router.currentRoute.value.path)
 const { t } = useI18n()
 
 const linkList = ref([

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <q-layout view="lHh Lpr lFf" class="bg-space-station">
-    <q-header ref="header">
-      <q-toolbar class="bg-space-station">
+    <q-header ref="header" class="bg-space-station">
+      <q-toolbar>
         <q-btn
           flat
           dense
@@ -37,6 +37,19 @@
           dense
         />
       </q-toolbar>
+
+      <div v-if="false" class="column items-center">
+        <div class="row q-gutter-xs q-pb-xs">
+          <q-btn
+            class="col justify-center q-px-sm"
+            color="negative"
+            icon="cancel"
+            size="sm"
+            dense
+            >filter
+          </q-btn>
+        </div>
+      </div>
     </q-header>
 
     <q-drawer

--- a/src/layouts/models/index.ts
+++ b/src/layouts/models/index.ts
@@ -1,0 +1,11 @@
+interface Button {
+  visible: boolean
+  disabled: boolean
+  action: Action
+}
+
+interface Action {
+  (): void
+}
+
+export { type Button, type Action }

--- a/src/layouts/models/index.ts
+++ b/src/layouts/models/index.ts
@@ -1,6 +1,8 @@
 interface Button {
   visible: boolean
   disabled: boolean
+  icon: string
+  color: string
   action: Action
 }
 

--- a/src/layouts/stores/index.ts
+++ b/src/layouts/stores/index.ts
@@ -1,0 +1,3 @@
+import { useMainLayoutStore } from './mainLayoutStore'
+
+export { useMainLayoutStore }

--- a/src/layouts/stores/mainLayoutStore.ts
+++ b/src/layouts/stores/mainLayoutStore.ts
@@ -18,10 +18,13 @@ export const useMainLayoutStore = defineStore('mainLayoutStore', () => {
     action: () => {}
   })
 
+  const calculateAreaHeight = () => {}
+
   return {
     titleText,
     badgesVisible,
     saveButton,
-    addButton
+    addButton,
+    calculateAreaHeight
   }
 })

--- a/src/layouts/stores/mainLayoutStore.ts
+++ b/src/layouts/stores/mainLayoutStore.ts
@@ -1,28 +1,56 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { Button } from '../models'
+import { Action, Button } from '../models'
 
 export const useMainLayoutStore = defineStore('mainLayoutStore', () => {
   const titleText = ref('')
 
-  const saveButton = ref<Button>({
+  const headerButton = ref<Button>({
     visible: false,
     disabled: false,
+    icon: 'save',
+    color: '',
     action: () => {}
   })
 
   const addButton = ref<Button>({
     visible: true,
     disabled: false,
+    icon: 'add',
+    color: '',
     action: () => {}
   })
+
+  function showButton(
+    button: Button,
+    action: Action,
+    icon: string,
+    disabled = false,
+    color = ''
+  ) {
+    button.visible = true
+    button.action = action
+    button.icon = icon
+    button.disabled = disabled
+    button.color = color
+  }
+
+  function hideButton(btn: Button) {
+    btn.visible = false
+    btn.action = () => {}
+    btn.icon = ''
+    btn.disabled = false
+    btn.color = ''
+  }
 
   const calculateAreaHeight = () => {}
 
   return {
     titleText,
-    saveButton,
+    headerButton,
     addButton,
+    showButton,
+    hideButton,
     calculateAreaHeight
   }
 })

--- a/src/layouts/stores/mainLayoutStore.ts
+++ b/src/layouts/stores/mainLayoutStore.ts
@@ -4,7 +4,6 @@ import { Button } from '../models'
 
 export const useMainLayoutStore = defineStore('mainLayoutStore', () => {
   const titleText = ref('')
-  const badgesVisible = ref(false)
 
   const saveButton = ref<Button>({
     visible: false,
@@ -22,7 +21,6 @@ export const useMainLayoutStore = defineStore('mainLayoutStore', () => {
 
   return {
     titleText,
-    badgesVisible,
     saveButton,
     addButton,
     calculateAreaHeight

--- a/src/layouts/stores/mainLayoutStore.ts
+++ b/src/layouts/stores/mainLayoutStore.ts
@@ -3,10 +3,14 @@ import { ref } from 'vue'
 
 export const useMainLayoutStore = defineStore('mainLayoutStore', () => {
   const titleText = ref('')
-  const showBadges = ref(false)
+  const badgesVisible = ref(false)
+  const saveButtonVisible = ref(false)
+  const saveButtonAction = () => {}
 
   return {
     titleText,
-    showBadges
+    badgesVisible,
+    saveButtonVisible,
+    saveButtonAction
   }
 })

--- a/src/layouts/stores/mainLayoutStore.ts
+++ b/src/layouts/stores/mainLayoutStore.ts
@@ -1,16 +1,27 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { Button } from '../models'
 
 export const useMainLayoutStore = defineStore('mainLayoutStore', () => {
   const titleText = ref('')
   const badgesVisible = ref(false)
-  const saveButtonVisible = ref(false)
-  const saveButtonAction = () => {}
+
+  const saveButton = ref<Button>({
+    visible: false,
+    disabled: false,
+    action: () => {}
+  })
+
+  const addButton = ref<Button>({
+    visible: true,
+    disabled: false,
+    action: () => {}
+  })
 
   return {
     titleText,
     badgesVisible,
-    saveButtonVisible,
-    saveButtonAction
+    saveButton,
+    addButton
   }
 })

--- a/src/layouts/stores/mainLayoutStore.ts
+++ b/src/layouts/stores/mainLayoutStore.ts
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useMainLayoutStore = defineStore('mainLayoutStore', () => {
+  const titleText = ref('')
+  const showBadges = ref(false)
+
+  return {
+    titleText,
+    showBadges
+  }
+})

--- a/src/pages/graphData/GraphData.vue
+++ b/src/pages/graphData/GraphData.vue
@@ -113,15 +113,15 @@ const optionsInDialog = ref([
 
 function editOrderFun(value = true) {
   editOrder.value = value
-  mainLayoutStore.saveButtonVisible = value
-  if (value) mainLayoutStore.saveButtonAction = () => saveOrder()
+  mainLayoutStore.saveButton.visible = value
+  if (value) mainLayoutStore.saveButton.action = () => saveOrder()
   else graphDataStore.readGraphData()
 }
 
 function saveOrder() {
   editOrder.value = false
   graphDataStore.saveCardOrder()
-  mainLayoutStore.saveButtonVisible = false
+  mainLayoutStore.saveButton.visible = false
 }
 
 function updateTitle() {
@@ -142,6 +142,7 @@ onMounted(async () => {
   await initSettings()
   periods.value = await graphDataStore.getPeriods()
   updateTitle()
+  mainLayoutStore.addButton.action = () => void router.push('/refuels/add')
   graphDataStore.readGraphData()
   App.removeAllListeners()
   App.addListener('backButton', () => {
@@ -153,7 +154,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  mainLayoutStore.saveButtonVisible = false
+  mainLayoutStore.saveButton.visible = false
   App.removeAllListeners()
 })
 </script>

--- a/src/pages/graphData/GraphData.vue
+++ b/src/pages/graphData/GraphData.vue
@@ -75,8 +75,9 @@ import GraphCard from 'src/pages/graphData/components/GraphCard.vue'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { emitter } from 'src/boot/mitt'
 import packageJson from '../../../package.json'
-import { useSettingsStore } from 'src/pages/settings/stores/settingsStore'
+import { useSettingsStore } from 'src/pages/settings/stores'
 import { useGraphDataStore } from './stores/graphDataStore'
+import { useMainLayoutStore } from 'src/layouts/stores'
 import { Period } from 'src/pages/graphData/scripts/models'
 import { optionsDialog } from 'src/components/dialogs/optionsDialog'
 import { useQuasar } from 'quasar'
@@ -94,6 +95,7 @@ $q.dark.set('auto')
 const router = useRouter()
 const graphDataStore = useGraphDataStore()
 const settingsStore = useSettingsStore()
+const mainLayoutStore = useMainLayoutStore()
 const { t } = useI18n({ useScope: 'local', messages })
 
 const loading = ref(false)
@@ -125,15 +127,12 @@ function saveOrder() {
 }
 
 function updateTitle() {
-  emitter.emit(
-    'updateTitle',
-    (() => {
-      if (!settingsStore.selectedVehicleId) return packageJson.productName
-      else if (settingsStore.plateNumberInTitleActive)
-        return settingsStore.selectedVehiclePlateNumber
-      return settingsStore.selectedVehicleName
-    })()
-  )
+  mainLayoutStore.titleText = (() => {
+    if (!settingsStore.selectedVehicleId) return packageJson.productName
+    else if (settingsStore.plateNumberInTitleActive)
+      return settingsStore.selectedVehiclePlateNumber
+    return settingsStore.selectedVehicleName
+  })()
 }
 
 function onDrop(dropResult: DropResult) {

--- a/src/pages/graphData/GraphData.vue
+++ b/src/pages/graphData/GraphData.vue
@@ -113,15 +113,22 @@ const optionsInDialog = ref([
 
 function editOrderFun(value = true) {
   editOrder.value = value
-  mainLayoutStore.saveButton.visible = value
-  if (value) mainLayoutStore.saveButton.action = () => saveOrder()
+  mainLayoutStore.headerButton.visible = value
+  if (value)
+    mainLayoutStore.showButton(
+      mainLayoutStore.headerButton,
+      () => saveOrder(),
+      'save',
+      false,
+      'accent'
+    )
   else graphDataStore.readGraphData()
 }
 
 function saveOrder() {
   editOrder.value = false
   graphDataStore.saveCardOrder()
-  mainLayoutStore.saveButton.visible = false
+  mainLayoutStore.headerButton.visible = false
 }
 
 function updateTitle() {
@@ -142,7 +149,6 @@ onMounted(async () => {
   await initSettings()
   periods.value = await graphDataStore.getPeriods()
   updateTitle()
-  mainLayoutStore.addButton.action = () => void router.push('/refuels/add')
   graphDataStore.readGraphData()
   App.removeAllListeners()
   App.addListener('backButton', () => {
@@ -154,7 +160,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  mainLayoutStore.saveButton.visible = false
+  mainLayoutStore.hideButton(mainLayoutStore.headerButton)
   App.removeAllListeners()
 })
 </script>

--- a/src/pages/graphData/GraphData.vue
+++ b/src/pages/graphData/GraphData.vue
@@ -73,7 +73,6 @@
 <script setup lang="ts">
 import GraphCard from 'src/pages/graphData/components/GraphCard.vue'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { emitter } from 'src/boot/mitt'
 import packageJson from '../../../package.json'
 import { useSettingsStore } from 'src/pages/settings/stores'
 import { useGraphDataStore } from './stores/graphDataStore'
@@ -114,16 +113,15 @@ const optionsInDialog = ref([
 
 function editOrderFun(value = true) {
   editOrder.value = value
-  emitter.emit('showSaveButton', value)
-  if (value) emitter.on('save', () => saveOrder())
+  mainLayoutStore.saveButtonVisible = value
+  if (value) mainLayoutStore.saveButtonAction = () => saveOrder()
   else graphDataStore.readGraphData()
 }
 
 function saveOrder() {
   editOrder.value = false
   graphDataStore.saveCardOrder()
-  emitter.off('save')
-  emitter.emit('showSaveButton', false)
+  mainLayoutStore.saveButtonVisible = false
 }
 
 function updateTitle() {
@@ -155,8 +153,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  emitter.emit('showSaveButton', false)
-  emitter.off('save')
+  mainLayoutStore.saveButtonVisible = false
   App.removeAllListeners()
 })
 </script>

--- a/src/pages/refuels/FilterRefuelsForm.vue
+++ b/src/pages/refuels/FilterRefuelsForm.vue
@@ -60,9 +60,9 @@
 import { onMounted, computed, onBeforeMount } from 'vue'
 import { date } from 'quasar'
 import { useRouter } from 'vue-router'
-import { emitter } from 'src/boot/mitt'
 import { requiredFieldRule } from 'src/scripts/libraries/validation'
 import { useRefuelFilterStore } from './stores'
+import { useMainLayoutStore } from 'src/layouts/stores'
 import CInput from 'src/components/inputs/CInput.vue'
 import { useI18n } from 'vue-i18n'
 import { i18n } from 'src/boot/i18n'
@@ -70,6 +70,7 @@ import messages from './i18n'
 
 const router = useRouter()
 const refuelFilterStore = useRefuelFilterStore()
+const mainLayoutStore = useMainLayoutStore()
 const { t } = useI18n({ useScope: 'local', messages })
 
 const filterDateFrom = computed(() => {
@@ -125,6 +126,6 @@ onBeforeMount(() => {
 })
 
 onMounted(() => {
-  emitter.emit('updateTitle', t('filterRefuelsForm.title'))
+  mainLayoutStore.titleText = t('filterRefuelsForm.title')
 })
 </script>

--- a/src/pages/refuels/RefuelForm.vue
+++ b/src/pages/refuels/RefuelForm.vue
@@ -111,7 +111,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { date as QuasarDate } from 'quasar'
 import { useRouter } from 'vue-router'
 import CInput from 'src/components/inputs/CInput.vue'
@@ -199,6 +199,7 @@ onMounted(async () => {
     mainLayoutStore.titleText = t('refuelsForm.titleAddRefuel')
   else if (routePath.includes('/edit'))
     mainLayoutStore.titleText = t('refuelsForm.titleEditRefuel')
+  mainLayoutStore.addButton.disabled = true
 
   vehicleName.value = settingsStore.plateNumberInTitleActive
     ? settingsStore.selectedVehiclePlateNumber
@@ -216,5 +217,9 @@ onMounted(async () => {
     refuelDate.value = QuasarDate.formatDate(refuel.value.date, 'YYYY/MM/DD')
     refuelTime.value = QuasarDate.formatDate(refuel.value.date, 'HH:mm')
   }
+})
+
+onBeforeUnmount(() => {
+  mainLayoutStore.addButton.disabled = false
 })
 </script>

--- a/src/pages/refuels/RefuelForm.vue
+++ b/src/pages/refuels/RefuelForm.vue
@@ -115,15 +115,15 @@ import { ref, onMounted } from 'vue'
 import { date as QuasarDate } from 'quasar'
 import { useRouter } from 'vue-router'
 import CInput from 'src/components/inputs/CInput.vue'
-import { emitter } from 'src/boot/mitt'
 import {
   requiredFieldRule,
   numbersOnlyRule,
   positiveNumbersRule,
   max50Characters
 } from 'src/scripts/libraries/validation'
-import { useSettingsStore } from 'src/pages/settings/stores/settingsStore'
+import { useSettingsStore } from 'src/pages/settings/stores'
 import { useRefuelStore } from './stores'
+import { useMainLayoutStore } from 'src/layouts/stores'
 import { Refuel } from 'src/scripts/libraries/refuel/models'
 import { replaceComma } from 'src/scripts/libraries/utils'
 import { useI18n } from 'vue-i18n'
@@ -133,6 +133,7 @@ import messages from './i18n'
 const router = useRouter()
 const refuelStore = useRefuelStore()
 const settingsStore = useSettingsStore()
+const mainLayoutStore = useMainLayoutStore()
 const { t } = useI18n({ useScope: 'local', messages })
 
 const refuel = ref<Refuel>(new Refuel())
@@ -195,9 +196,9 @@ function onCancel() {
 onMounted(async () => {
   routePath = router.currentRoute.value.path.toLocaleLowerCase()
   if (routePath.includes('/add'))
-    emitter.emit('updateTitle', t('refuelsForm.titleAddRefuel'))
+    mainLayoutStore.titleText = t('refuelsForm.titleAddRefuel')
   else if (routePath.includes('/edit'))
-    emitter.emit('updateTitle', t('refuelsForm.titleEditRefuel'))
+    mainLayoutStore.titleText = t('refuelsForm.titleEditRefuel')
 
   vehicleName.value = settingsStore.plateNumberInTitleActive
     ? settingsStore.selectedVehiclePlateNumber

--- a/src/pages/refuels/Refuels.vue
+++ b/src/pages/refuels/Refuels.vue
@@ -61,7 +61,11 @@
 
       <Teleport to="#header-badges-left">
         <div class="q-px-md q-pb-xs q-gutter-md">
-          <q-badge>{{ vehicleName }}</q-badge>
+          <q-badge>{{
+            settingsStore.plateNumberInTitleActive
+              ? settingsStore.selectedVehiclePlateNumber
+              : settingsStore.selectedVehicleName
+          }}</q-badge>
         </div>
       </Teleport>
       <Teleport to="#header-badges-center">
@@ -114,7 +118,6 @@ const mainLayoutStore = useMainLayoutStore()
 const { t } = useI18n({ useScope: 'local', messages })
 
 const vehiclesExists = settingsStore.selectedVehicleId
-const vehicleName = ref<string>('')
 const loading = ref(true)
 const virtualListRef = ref(null)
 const areaHeight = computed(() => `height: ${settingsStore.areaHeight}px`)
@@ -181,12 +184,6 @@ emitter.on('showRefuelOptionsDialog', id =>
 
 onBeforeMount(async () => {
   mainLayoutStore.titleText = t('refuels.title')
-  mainLayoutStore.addButton.action = () => void router.push('/refuels/add')
-
-  vehicleName.value = settingsStore.plateNumberInTitleActive
-    ? settingsStore.selectedVehiclePlateNumber
-    : settingsStore.selectedVehicleName
-
   await refuelStore.readData()
 
   // Define to which index to scroll
@@ -214,10 +211,16 @@ watch(
 )
 
 onMounted(() => {
+  mainLayoutStore.showButton(
+    mainLayoutStore.headerButton,
+    () => void router.push('/refuels/filter'),
+    'filter_list'
+  )
   mainLayoutStore.calculateAreaHeight()
 })
 
 onUnmounted(() => {
+  mainLayoutStore.hideButton(mainLayoutStore.headerButton)
   emitter.off('showRefuelOptionsDialog')
 })
 </script>

--- a/src/pages/refuels/Refuels.vue
+++ b/src/pages/refuels/Refuels.vue
@@ -175,6 +175,7 @@ emitter.on('showRefuelOptionsDialog', id =>
 
 onBeforeMount(async () => {
   mainLayoutStore.titleText = t('refuels.title')
+  mainLayoutStore.addButton.action = () => void router.push('/refuels/add')
 
   vehicleName.value = settingsStore.plateNumberInTitleActive
     ? settingsStore.selectedVehiclePlateNumber

--- a/src/pages/refuels/Refuels.vue
+++ b/src/pages/refuels/Refuels.vue
@@ -93,6 +93,7 @@ import { Refuel } from 'src/scripts/libraries/refuel/models'
 import { vehicleFuelConsumption } from 'src/scripts/libraries/refuel/functions/vehicle'
 import { QVirtualScroll } from 'quasar'
 import { useRefuelStore, useRefuelFilterStore } from './stores'
+import { useMainLayoutStore } from 'src/layouts/stores'
 import { useI18n } from 'vue-i18n'
 import { i18n } from 'src/boot/i18n'
 import messages from './i18n'
@@ -101,6 +102,7 @@ const router = useRouter()
 const settingsStore = useSettingsStore()
 const refuelStore = useRefuelStore()
 const refuelFilterStore = useRefuelFilterStore()
+const mainLayoutStore = useMainLayoutStore()
 const { t } = useI18n({ useScope: 'local', messages })
 
 const vehiclesExists = settingsStore.selectedVehicleId
@@ -169,7 +171,7 @@ emitter.on('showRefuelOptionsDialog', id =>
 )
 
 onBeforeMount(async () => {
-  emitter.emit('updateTitle', t('refuels.title'))
+  mainLayoutStore.titleText = t('refuels.title')
 
   vehicleName.value = settingsStore.plateNumberInTitleActive
     ? settingsStore.selectedVehiclePlateNumber

--- a/src/pages/settings/Settings.vue
+++ b/src/pages/settings/Settings.vue
@@ -104,7 +104,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import CSelect from 'src/components/inputs/CSelect.vue'
-import { emitter } from 'src/boot/mitt'
 import { useSettingsStore } from 'src/pages/settings/stores/settingsStore'
 import { exportDB, importDB } from 'src/scripts/libraries/backup/backup'
 import { FilePicker } from 'src/plugins/capacitor-file-picker'
@@ -117,9 +116,11 @@ import {
   setI18nLanguage
 } from 'src/scripts/libraries/utils/language'
 import { LanugageId } from '../../scripts/models'
+import { useMainLayoutStore } from 'src/layouts/stores'
 
 const { t } = useI18n({ useScope: 'global', messages })
 const settingsStore = useSettingsStore()
+const mainLayoutStore = useMainLayoutStore()
 
 type GetContentResultAction = (result: { path: string }) => void
 let getContentResultAction: GetContentResultAction
@@ -152,19 +153,7 @@ const colorThemeOptions = [
   }
 ]
 
-// const distanceUnitOptions = [
-//   {
-//     label: 'km',
-//     value: 1
-//   },
-//   {
-//     label: 'miles',
-//     value: 2
-//   }
-// ]
-
 const colorTheme = ref(settingsStore.selectedColorThemeId)
-// const distanceUnit = ref(settingsStore.selectedDistanceUnitId)
 const plateNumberInTitle = ref(settingsStore.plateNumberInTitleActive)
 const autoBackup = ref(settingsStore.autoBackupActive)
 
@@ -175,12 +164,8 @@ function changeColorTheme(value: number) {
 async function changeLanguage(languageId: number) {
   settingsStore.changeLanguage(languageId)
   await setI18nLanguage(languageId)
-  emitter.emit('updateTitle', t('title'))
+  mainLayoutStore.titleText = t('title')
 }
-
-// function changeDistanceUnit(value: number) {
-//   settingsStore.changeDistanceUnit(value)
-// }
 
 function togglePlateNumberInTitle(value: boolean) {
   settingsStore.togglePlateNumberInTitle(value)
@@ -227,7 +212,7 @@ async function importBackup() {
 }
 
 onMounted(() => {
-  emitter.emit('updateTitle', t('title'))
+  mainLayoutStore.titleText = t('title')
   currentLanguage.value = settingsStore.selectedLanguageId
   if (Platform.is.mobile) {
     FilePicker.addListener('getContentResult', res => {

--- a/src/pages/settings/stores/settingsStore.ts
+++ b/src/pages/settings/stores/settingsStore.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia'
 import { Vehicle } from 'src/scripts/libraries/refuel/models'
 import { ref } from 'vue'
-import { emitter } from 'src/boot/mitt'
 import {
   settingsRepository,
   vehicleRepository
@@ -51,8 +50,6 @@ export const useSettingsStore = defineStore('settingsStore', () => {
       if (!settings) return Promise.resolve()
       settings.vehicleId = vehicle.id
       await settingsRepository.updateSettings(settings)
-
-      emitter.emit('selectedVehicleChanged', true)
       return Promise.resolve()
     } else {
       selectedVehicleId.value = null

--- a/src/pages/support/Support.vue
+++ b/src/pages/support/Support.vue
@@ -113,18 +113,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { onMounted, ref } from 'vue'
 import packageJson from '../../../package.json'
 import { openURL } from 'quasar'
-import { emitter } from '../../boot/mitt'
 import { useI18n } from 'vue-i18n'
 import messages from './i18n'
+import { useMainLayoutStore } from 'src/layouts/stores'
 
-const router = useRouter()
+const mainLayoutStore = useMainLayoutStore()
 const { t } = useI18n({ useScope: 'global', messages })
-
-const routePath = computed(() => router.currentRoute.value.path)
 const ratingModel = ref(3)
 const slide = ref('code')
 const repositoryLink = 'https://github.com/MatiasG19/refuel-tracker'
@@ -132,10 +129,7 @@ const licenseLink =
   'https://github.com/MatiasG19/refuel-tracker/blob/main/LICENSE'
 const issueLink = 'https://github.com/MatiasG19/refuel-tracker/issues/new'
 
-const emits = defineEmits(['update:title'])
-
 onMounted(() => {
-  emits('update:title', routePath.value)
-  emitter.emit('updateTitle', t('title'))
+  mainLayoutStore.titleText = t('title')
 })
 </script>

--- a/src/pages/vehicles/VehicleForm.vue
+++ b/src/pages/vehicles/VehicleForm.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, toRaw } from 'vue'
+import { ref, onMounted, toRaw, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import CInput from 'src/components/inputs/CInput.vue'
 import CSelect from 'src/components/inputs/CSelect.vue'
@@ -117,6 +117,12 @@ onMounted(async () => {
     mainLayoutStore.titleText = t('vehicleForm.titleAddVehicle')
   else if (routePath.includes('/edit'))
     mainLayoutStore.titleText = t('vehicleForm.titleEditVehicle')
+
+  mainLayoutStore.addButton.disabled = true
+})
+
+onBeforeUnmount(() => {
+  mainLayoutStore.addButton.disabled = false
 })
 </script>
 

--- a/src/pages/vehicles/VehicleForm.vue
+++ b/src/pages/vehicles/VehicleForm.vue
@@ -52,7 +52,6 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import CInput from 'src/components/inputs/CInput.vue'
 import CSelect from 'src/components/inputs/CSelect.vue'
-import { emitter } from 'src/boot/mitt'
 import {
   requiredFieldRule,
   max50Characters
@@ -64,10 +63,12 @@ import { Vehicle } from 'src/scripts/libraries/refuel/models'
 import { useI18n } from 'vue-i18n'
 import { i18n } from 'src/boot/i18n'
 import messages from './i18n'
+import { useMainLayoutStore } from 'src/layouts/stores'
 
 const router = useRouter()
 const vehicleStore = useVehicleStore()
 const settingsStore = useSettingsStore()
+const mainLayoutStore = useMainLayoutStore()
 const { t } = useI18n({ useScope: 'local', messages })
 
 const vehicle = ref<Vehicle>(new Vehicle())
@@ -115,9 +116,9 @@ onMounted(async () => {
   // Update title
   routePath = router.currentRoute.value.path.toLocaleLowerCase()
   if (routePath.includes('/add'))
-    emitter.emit('updateTitle', t('vehicleForm.titleAddVehicle'))
+    mainLayoutStore.titleText = t('vehicleForm.titleAddVehicle')
   else if (routePath.includes('/edit'))
-    emitter.emit('updateTitle', t('vehicleForm.titleEditVehicle'))
+    mainLayoutStore.titleText = t('vehicleForm.titleEditVehicle')
 })
 </script>
 

--- a/src/pages/vehicles/Vehicles.vue
+++ b/src/pages/vehicles/Vehicles.vue
@@ -40,10 +40,12 @@ import { useQuasar } from 'quasar'
 import { useI18n } from 'vue-i18n'
 import { i18n } from 'src/boot/i18n'
 import messages from './i18n'
+import { useMainLayoutStore } from 'src/layouts/stores'
 
 const router = useRouter()
 const vehicleStore = useVehicleStore()
 const settingsStore = useSettingsStore()
+const mainLayoutStore = useMainLayoutStore()
 const $q = useQuasar()
 const { t } = useI18n({ useScope: 'local', messages })
 
@@ -104,7 +106,7 @@ async function selectVehicle(vehicle: Vehicle) {
 }
 
 onMounted(async () => {
-  emitter.emit('updateTitle', t('vehicles.title'))
+  mainLayoutStore.titleText = t('vehicles.title')
   await vehicleStore.readVehicles()
 })
 

--- a/src/pages/vehicles/Vehicles.vue
+++ b/src/pages/vehicles/Vehicles.vue
@@ -106,6 +106,7 @@ async function selectVehicle(vehicle: Vehicle) {
 onMounted(async () => {
   mainLayoutStore.titleText = t('vehicles.title')
   await vehicleStore.readVehicles()
+  mainLayoutStore.addButton.action = () => void router.push('/vehicles/add')
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
# refactor(mainlayout api): Use vue native functions instead of events
- Use mainlayout store instead of events or relying or route names, this allows a clearer api
- Fix english translation on refuels filter page
- Fix double scrollbar on refuels page
- Change style of filter badge and save button

## Checklist

Check all boxes that apply:

- [ ] Tests created
- [ ] Changes tested on latest device API
- [X] Self review of changes
- [X] Pipeline ok
