### PR TITLE
fix(refuel): Fix date after deleting refuel

### DIFF
--- a/src/pages/refuels/components/RefuelCard.vue
+++ b/src/pages/refuels/components/RefuelCard.vue
@@ -5,7 +5,9 @@
         <q-card-section>
           <div class="row items-center no-wrap">
             <div class="col">
-              <div class="text-subtitle2">{{ refuelDate }}</div>
+              <div class="text-subtitle2">
+                {{ date.formatDate(props.refuel.date, 'YYYY-MMM-DD HH:mm') }}
+              </div>
             </div>
             <div class="col-auto space-station">
               <q-btn
@@ -82,6 +84,4 @@ const props = defineProps({
     type: Boolean
   }
 })
-
-const refuelDate = date.formatDate(props.refuel.date, 'YYYY-MMM-DD HH:mm')
 </script>


### PR DESCRIPTION
# fix(refuel): Fix date after deleting refuel

- Date didn't update in refuel card after deleting refuel, since it was not reactive

## Checklist

Check all boxes that apply:

- [ ] Tests created
- [ ] Changes tested on latest device API
- [X] Self review of changes
- [X] Pipeline ok
