### PR TITLE
fix(graphPage): Set vehicle id after adding vehicle

### DIFF
--- a/src/pages/vehicles/stores/vehicleStore.ts
+++ b/src/pages/vehicles/stores/vehicleStore.ts
@@ -42,7 +42,7 @@ export const useVehicleStore = defineStore('vehicleStore', () => {
 
   async function addVehicle(vehicle: Vehicle) {
     vehicles.value.push(vehicle)
-    await vehicleRepository.addVehicle(vehicle)
+    vehicle.id = await vehicleRepository.addVehicle(vehicle)
     settingsStore.changeSelectedVehicle(vehicle)
     await vehicleAddedEvent(vehicle)
   }


### PR DESCRIPTION
# fix(graphPage): Set vehicle id after adding vehicle
Graph page showed "Add vehicle" instead "Add refuel", because selected vehicle id was set to undifined.

## Checklist

Check all boxes that apply:

- [ ] Tests created
- [ ] Changes tested on latest device API
- [X] Self review of changes
- [X] Pipeline ok
