### PR TITLE
chore(permissions): Remove media permissions

### DIFF
--- a/src-capacitor/android/app/src/main/AndroidManifest.xml
+++ b/src-capacitor/android/app/src/main/AndroidManifest.xml
@@ -3,10 +3,6 @@
     >
 
     <!-- Permissions -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
       android:maxSdkVersion="32" />


### PR DESCRIPTION
# chore(permissions): Remove media permissions

Remove READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions to comply with Google Play policies.

## Checklist

Check all boxes that apply:

- [ ] Tests created
- [X] Changes tested on latest device API
- [X] Self review of changes
- [X] Pipeline ok
